### PR TITLE
Adding a section in the Mini-HowTo about traversing the list using agents

### DIFF
--- a/documentation/trunk/eiffel/Tutorials/Mini-HowTo/Iterating-on-a-LIST.wiki
+++ b/documentation/trunk/eiffel/Tutorials/Mini-HowTo/Iterating-on-a-LIST.wiki
@@ -1,7 +1,7 @@
 [[Property:uuid|96077603-DD2D-4D8C-A486-AF4BD066613A]]
 [[Property:weight|2000]]
 [[Property:title|Iterating on a LIST]]
-There are two Eiffel mechanisms to iterate on every element of a <code>LIST</code>.
+There are three Eiffel mechanisms to iterate on every element of a <code>LIST</code>.
 
 The first it the <code>across</code> loop. The <code>across</code> can be used on every <code>ITERABLE</code> object (including <code>LIST</code> objects).
 
@@ -17,7 +17,7 @@ The first it the <code>across</code> loop. The <code>across</code> can be used o
 
 Note that the temporary variable (<code>la_list</code> in the example) represent an iterator of the <code>ITERABLE</code> object, and not directly an element like in many other languages (like the <code>for</code> structure in Python for example).
 
-The other mechanism uses the <code>from until</code> loop syntax. This syntax offer more possibilities than the <code>across</code> loop, but is riskier.
+The second mechanism uses the <code>from until</code> loop syntax. This syntax offer more possibilities than the <code>across</code> loop, but is riskier.
 
 <code>
 	print_elements(a_list:LIST[INTEGER])
@@ -32,4 +32,28 @@ The other mechanism uses the <code>from until</code> loop syntax. This syntax of
 				a_list.forth
 			end
 		end
+</code>
+
+A third mechanism uses Eiffel agents in conjunction with the <code>LIST</code> features <code>do_all</code>, <code>do_if</code>, <code>there_exists</code>, and <code>for_all</code> which are inherited from the class <code>LINEAR</code>.
+<code>
+list_traversal_agents
+			-- Example of traversing a list with do_all
+		local
+			a_list: LINKED_LIST [STRING]
+		do
+				-- Insert some elements in a_list
+			create a_list.make
+			a_list.extend ("The Moon Is Full")
+			a_list.extend ("Master charge")
+			a_list.extend ("Black cat bone")
+			a_list.do_all (agent {STRING}.append(" - Albert Collins"))
+			a_list.do_all (agent print_element_action)
+		end
+
+	print_element_action (s: STRING)
+		do
+			io.put_string (s)
+			io.put_new_line
+		end
+
 </code>

--- a/documentation/trunk/eiffel/Tutorials/Mini-HowTo/Iterating-on-a-LIST.wiki
+++ b/documentation/trunk/eiffel/Tutorials/Mini-HowTo/Iterating-on-a-LIST.wiki
@@ -50,9 +50,10 @@ list_traversal_agents
 			a_list.do_all (agent print_element_action)
 		end
 
-	print_element_action (s: STRING)
+	print_element_action (a_element: STRING)
+			-- Print a_element to standard output
 		do
-			io.put_string (s)
+			io.put_string (a_element)
 			io.put_new_line
 		end
 


### PR DESCRIPTION
I extended the "Iterating on a LIST" Mini-HowTo to include Eiffel agents. I included one example using the feature <code>do_all</code>. If convenient I would like to add two or three more examples using other traversal features in the <code>LIST</code> base class.